### PR TITLE
Solve for when image or container lists have empty fields

### DIFF
--- a/lib/docker/parser.ex
+++ b/lib/docker/parser.ex
@@ -21,7 +21,12 @@ defmodule Docker.Parser do
   end
 
   def parse_field(raw_field) do
-    [key, value] = raw_field |> String.split(": ", parts: 2)
+    [key, value] =
+      if String.match?(raw_field, ~r/.+: .+/) do
+        raw_field |> String.split(": ", parts: 2)
+      else
+        raw_field |> String.split(":", parts: 2)
+      end
 
     {key |> String.downcase |> String.to_atom, value}
   end


### PR DESCRIPTION
I've encountered an error with the parser:

![screenshot 2017-06-27 14 59 52](https://user-images.githubusercontent.com/21684087/27588723-615887b8-5b49-11e7-9b0b-6ea5d11e8732.png)

Turns out, this happens when the container lists has empty fields:

![screenshot 2017-06-27 15 02 18](https://user-images.githubusercontent.com/21684087/27588796-a9d48974-5b49-11e7-89ae-3dc02ddc185b.png)

So, I propose this solution. I've used my fork in the affected project and it worked as expected.